### PR TITLE
Add hostConfig map support, robust async loading, image sizing fallback, and media aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Other constructors:
 * `AdaptiveCard.asset` → Load card from a local asset
 * `AdaptiveCard.memory` → Load from an in-memory JSON map
 
+You can provide host config either as an asset path (`hostConfigPath`) **or** as a decoded map (`hostConfigMap`).
+If you use `hostConfigPath`, point to a bundled asset path (for example `assets/host_config.json`) declared in your app `pubspec.yaml` — do not pass `lib/...`.
+Use `hostConfigMap` when your host config JSON lives in code and is not bundled as a Flutter asset.
+
 ---
 
 ## 🧪 Running Tests

--- a/lib/src/elements/basics.dart
+++ b/lib/src/elements/basics.dart
@@ -665,10 +665,11 @@ class _AdaptiveImageSetState extends State<AdaptiveImageSet>
       adaptiveMap: adaptiveMap,
       child: LayoutBuilder(
         builder: (context, constraints) {
+          final fallbackWidth = MediaQuery.sizeOf(context).width;
           return Wrap(
             children: images
                 .map((img) => SizedBox(
-              width: calculateSize(constraints),
+              width: calculateSize(constraints, fallbackWidth),
               child: img,
             ))
                 .toList(),
@@ -678,16 +679,23 @@ class _AdaptiveImageSetState extends State<AdaptiveImageSet>
     );
   }
 
-  double calculateSize(BoxConstraints constraints) {
+  double calculateSize(BoxConstraints constraints, double fallbackWidth) {
+    final finiteFallbackWidth =
+        (fallbackWidth.isFinite && fallbackWidth > 0) ? fallbackWidth : 300.0;
+    final maxWidth =
+        (constraints.maxWidth.isFinite && constraints.maxWidth > 0)
+            ? constraints.maxWidth
+            : finiteFallbackWidth;
+
     if (maybeSize != null) return maybeSize!;
-    if (imageSize == "stretch") return constraints.maxWidth;
+    if (imageSize == "stretch") return maxWidth;
     final count = images.length;
     if (count >= 5) {
-      return constraints.maxWidth / 5;
+      return maxWidth / 5;
     } else if (count == 0) {
       return 0.0;
     } else {
-      return constraints.maxWidth / count;
+      return maxWidth / count;
     }
   }
 
@@ -776,7 +784,10 @@ class _AdaptiveMediaState extends State<AdaptiveMedia>
   Widget build(BuildContext context) {
     return SeparatorElement(
       adaptiveMap: adaptiveMap,
-      child: Chewie(controller: controller),
+      child: AspectRatio(
+        aspectRatio: controller.aspectRatio ?? (3 / 2),
+        child: Chewie(controller: controller),
+      ),
     );
   }
 }


### PR DESCRIPTION
### Motivation

- Allow providing Adaptive Card host configuration as an in-memory decoded map in addition to an asset path to make embedding easier and avoid asset bundling pitfalls.
- Make async content loading more robust with proper error handling and a visible fallback when loading fails.
- Fix image grid layout in unconstrained contexts by using a reliable width fallback and improve video rendering by respecting aspect ratio.

### Description

- Update `AdaptiveCardContentProvider` to accept an optional `hostConfig` map and assert that either `hostConfigPath` or `hostConfig` is provided, and update `loadHostConfig` to prefer the provided map and produce clearer `FlutterError` messages for invalid paths or bad JSON. 
- Add optional `hostConfigMap` parameters to `AdaptiveCard.network`, `AdaptiveCard.asset`, and `AdaptiveCard.memory` constructors and propagate the host config into the corresponding content providers, with constructor `assert` checks.
- Refactor async loading in `AdaptiveCard` into `_loadAsyncSources`, expose `_loadError`, and render a helpful error/placeholder via `_buildLoadError` when loading fails; include debug printing of the error in asserts.
- In `lib/src/elements/basics.dart` make `_AdaptiveImageSetState` compute a `fallbackWidth` from `MediaQuery.sizeOf(context).width` and change `calculateSize` to use a finite fallback when `constraints.maxWidth` is unbounded; ensure `stretch` and distribution calculations use the resolved max width.
- Wrap the `Chewie` video player in an `AspectRatio` in `_AdaptiveMediaState` to respect `controller.aspectRatio` (falling back to `3/2`) and prevent sizing issues.
- Update `README.md` to document the new `hostConfigMap` option and to explain asset path guidance for `hostConfigPath`.

### Testing

- Ran `flutter analyze` and fixed issues introduced by the changes; analysis completed successfully.
- Ran `flutter test` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ea5787e88326a3a271952eda050f)