### PR TITLE
Resolve font weights with explicit mapping, bump to 1.0.3, and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,6 @@
-## 1.0.0 – Initial Release
-- Updated codebase for Flutter 3.35.2
-- Improved stability and structure
-- Modernized library under MIT License
+## 1.0.3
 
-## 1.0.1
-
-- Fix handling of broken image URLs causing infinite loading
-- Improve media and markdown image error handling
+- Update `resolveFontWeight` to use an explicit numeric-to-`FontWeight` mapping with a safe fallback to `FontWeight.normal`
 
 ## 1.0.2
 
@@ -14,3 +8,14 @@
 - Improve async adaptive card loading with clearer failure fallback/error visibility
 - Fix adaptive image/media sizing issues that could cause gray or unbounded layouts in release builds
 - Add host config usage guidance for asset paths vs in-memory map configuration
+
+## 1.0.1
+
+- Fix handling of broken image URLs causing infinite loading
+- Improve media and markdown image error handling
+
+## 1.0.0 – Initial Release
+
+- Updated codebase for Flutter 3.35.2
+- Improved stability and structure
+- Modernized library under MIT License

--- a/lib/src/flutter_adaptive_cards.dart
+++ b/lib/src/flutter_adaptive_cards.dart
@@ -575,8 +575,20 @@ class ReferenceResolver {
 
   FontWeight resolveFontWeight(String? value) {
     final int weight = resolve("fontWeights", value ?? "default") as int;
-    return FontWeight.values
-        .firstWhere((w) => w.toString() == "FontWeight.w$weight");
+
+    const map = {
+      100: FontWeight.w100,
+      200: FontWeight.w200,
+      300: FontWeight.w300,
+      400: FontWeight.w400,
+      500: FontWeight.w500,
+      600: FontWeight.w600,
+      700: FontWeight.w700,
+      800: FontWeight.w800,
+      900: FontWeight.w900,
+    };
+
+    return map[weight] ?? FontWeight.normal;
   }
 
   double resolveFontSize(String? value) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_adaptive_cards_plus
 description: A Flutter implementation of Adaptive Cards, updated for Flutter 3.35.2.
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/HRCJ7/flutter_adaptive_cards_plus
 repository: https://github.com/HRCJ7/flutter_adaptive_cards_plus
 issue_tracker: https://github.com/HRCJ7/flutter_adaptive_cards_plus/issues


### PR DESCRIPTION
### Motivation

- Ensure `resolveFontWeight` reliably maps numeric font weight values from host config to Flutter `FontWeight` constants and avoids runtime failures when encountering unexpected values.
- Publish a patch release with the fix by bumping the package version to `1.0.3`.
- Keep the project history clear by updating and reordering `CHANGELOG.md` to reflect the new release and related notes.

### Description

- Replace fragile `FontWeight` lookup in `ReferenceResolver.resolveFontWeight` with an explicit numeric-to-`FontWeight` map and a safe fallback to `FontWeight.normal` for unknown weights.  
- Bump package version in `pubspec.yaml` from `1.0.2` to `1.0.3`.  
- Update `CHANGELOG.md` to add a `1.0.3` section describing the `resolveFontWeight` change and reorder/rephrase prior release entries for clarity.

### Testing

- Ran `dart analyze` and static analysis passed without new issues.  
- Ran `flutter test` and existing test suites completed successfully (no failing tests).  
- Manual inspection of the changed `resolveFontWeight` logic was done to ensure the fallback behavior maps unexpected values to `FontWeight.normal`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a693a1b26083268f1c242fd63cad39)